### PR TITLE
Handle disconnects and initial connection timeouts.

### DIFF
--- a/Assets/GRPC.NET/Scripts/PushPullStream.cs
+++ b/Assets/GRPC.NET/Scripts/PushPullStream.cs
@@ -18,6 +18,8 @@ namespace GRPC.NET
         private bool m_Flushed;
         private bool m_Closed;
 
+        private Exception m_Exception;
+
         public Action OnStreamFlushCallback;
 
         public PushPullStream(string name)
@@ -53,6 +55,9 @@ namespace GRPC.NET
 
         private bool ReadAvailable(int count)
         {
+            if (m_Exception != null)
+                throw m_Exception;
+
             // Either we have data to read, or we got flushed (e.g. stream got closed)
             // or we are in non blocking read mode.
             return Length >= count && m_Flushed || m_Closed || NonBlockingRead;
@@ -87,8 +92,11 @@ namespace GRPC.NET
             OnStreamFlushCallback?.Invoke();
         }
 
-        public override void Close()
+        public override void Close() => CloseWithException(null);
+
+        public void CloseWithException(Exception ex)
         {
+            m_Exception = ex;
             m_Closed = true;
             Flush();
         }

--- a/grpc-example-server/build.gradle
+++ b/grpc-example-server/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'io.grpc:grpc-netty:1.49.2'
     implementation "io.grpc:grpc-protobuf:1.49.2"
     implementation "io.grpc:grpc-stub:1.49.2"
+    implementation "javax.annotation:javax.annotation-api:1.3.2"
 }
 
 protobuf {

--- a/grpc-example-server/src/main/java/net/grpc/example/HelloWorldServer.java
+++ b/grpc-example-server/src/main/java/net/grpc/example/HelloWorldServer.java
@@ -1,6 +1,5 @@
 package net.grpc.example;
 
-import com.sun.media.jfxmedia.logging.Logger;
 import io.grpc.*;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
@@ -18,7 +17,6 @@ public class HelloWorldServer {
     private Server server;
 
     public void start() throws IOException {
-        Logger.setLevel(Logger.DEBUG);
 
         SslContextBuilder scb = SslContextBuilder.forServer(new File("cert.pem"), new File("key.pem"));
         GrpcSslContexts.configure(scb, SslProvider.JDK);

--- a/grpc-example-server/src/main/java/net/grpc/example/HelloWorldServiceImpl.java
+++ b/grpc-example-server/src/main/java/net/grpc/example/HelloWorldServiceImpl.java
@@ -1,5 +1,6 @@
 package net.grpc.example;
 
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import net.grpc.example.protos.HelloRequest;
 import net.grpc.example.protos.HelloResponse;
@@ -15,12 +16,26 @@ public class HelloWorldServiceImpl extends HelloWorldServiceGrpc.HelloWorldServi
 
     @Override
     public void hello(HelloRequest request, StreamObserver<HelloResponse> responseObserver) {
+        String req = request.getText();
         System.out.println("hello() called");
-        System.out.println(" > received " + request.getText());
+        System.out.println(" > received " + req);
 
-        String txt = "Hello " + request.getText();
-        System.out.println(" > send " + txt + " + done");
-        responseObserver.onNext(HelloResponse.newBuilder().setText(txt).build());
+        if (!req.contains("[no-response]")) {
+            if (req.contains("[exception-before]")) {
+                responseObserver.onError(Status.INVALID_ARGUMENT.withDescription("Before Response Exception").asException());
+                return;
+            }
+
+            String txt = "Hello " + req;
+            System.out.println(" > send " + txt + " + done");
+            responseObserver.onNext(HelloResponse.newBuilder().setText(txt).build());
+
+            if (req.contains("[exception-after]")) {
+                responseObserver.onError(Status.INTERNAL.withDescription("After Response Exception").asException());
+                return;
+            }
+        }
+
         responseObserver.onCompleted();
     }
 

--- a/grpc-example-server/src/main/java/net/grpc/example/HelloWorldServiceImpl.java
+++ b/grpc-example-server/src/main/java/net/grpc/example/HelloWorldServiceImpl.java
@@ -16,21 +16,21 @@ public class HelloWorldServiceImpl extends HelloWorldServiceGrpc.HelloWorldServi
 
     @Override
     public void hello(HelloRequest request, StreamObserver<HelloResponse> responseObserver) {
-        String req = request.getText();
+        String message = request.getText();
         System.out.println("hello() called");
-        System.out.println(" > received " + req);
+        System.out.println(" > received " + message);
 
-        if (!req.contains("[no-response]")) {
-            if (req.contains("[exception-before]")) {
+        if (!message.contains("[no-response]")) {
+            if (message.contains("[exception-before]")) {
                 responseObserver.onError(Status.INVALID_ARGUMENT.withDescription("Before Response Exception").asException());
                 return;
             }
 
-            String txt = "Hello " + req;
+            String txt = "Hello " + message;
             System.out.println(" > send " + txt + " + done");
             responseObserver.onNext(HelloResponse.newBuilder().setText(txt).build());
 
-            if (req.contains("[exception-after]")) {
+            if (message.contains("[exception-after]")) {
                 responseObserver.onError(Status.INTERNAL.withDescription("After Response Exception").asException());
                 return;
             }
@@ -68,12 +68,20 @@ public class HelloWorldServiceImpl extends HelloWorldServiceGrpc.HelloWorldServi
 
             @Override
             public void onNext(HelloRequest request) {
-                System.out.println(" > received " + request.getText());
+                String message = request.getText();
+                System.out.println(" > received " + message);
+
+                if (message.contains("[stop]")) {
+                    responseObserver.onError(Status.INTERNAL.withDescription("Abort from Server side").asException());
+                }
+
                 count++;
             }
 
             @Override
-            public void onError(Throwable t) { }
+            public void onError(Throwable t) {
+                System.out.println(" > received error: " + t.getMessage());
+            }
 
             @Override
             public void onCompleted() {
@@ -102,7 +110,9 @@ public class HelloWorldServiceImpl extends HelloWorldServiceGrpc.HelloWorldServi
             }
 
             @Override
-            public void onError(Throwable t) { }
+            public void onError(Throwable t) {
+                System.out.println(" > received error: " + t.getMessage());
+            }
 
             @Override
             public void onCompleted() {


### PR DESCRIPTION
Currently the code ignores cases where the http2 connection is completed but no status was send by the server. This handler adds the possibility to fail when no connection is possible or when the connection was terminated unexpectedly.

Should resolve https://github.com/doctorseus/grpc-dotnet-unity/issues/3.